### PR TITLE
Add support for Netpbm PAM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ time = "0.1"
 [dependencies.image]
 default-features = false
 version = "0.19"
-features = ["png_codec"]
+features = ["png_codec", "pnm"]
 
 [dependencies.x11]
 version = "2.18"

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ Further profiling has shown that the bottleneck in shotgun lies fully within the
 PNG encoder.
 
 ### Going faster
+
 The PNG encoder bottleneck can be avoided by using `-f pam`. This sets the output format to
 [Netpbm PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format) - an uncompressed binary image format.
 
 By using an uncompressed format both encoding and decoding performance is improved:
 
 #### Encoding
+
 ```
 >>> for i in {1..5}; do time ./target/release/shotgun -f png - > /dev/null; done
 ./target/release/shotgun -f png - > /dev/null  0.32s user 0.11s system 99% cpu 0.434 total
@@ -124,6 +126,7 @@ By using an uncompressed format both encoding and decoding performance is improv
 ```
 
 #### Decoding (using ImageMagick to convert to jpg)
+
 ```
 >>> for i in {1..5}; do time ./target/release/shotgun -f png - | convert - jpg:- > /dev/null; done
 convert - jpg:- > /dev/null  0.59s user 0.16s system 89% cpu 0.842 total

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ shotgun $sel $*
 
 ## shotgun vs maim
 
-- Only PNG and PAM are supported
+- Only PNG and [PAM](#going-faster) are supported
 - Does not attempt to wrap slop
 - No cursor blending
 - Defaults to a time-stamped file instead of dumping raw PNG data into your
@@ -48,7 +48,7 @@ shotgun $sel $*
 There are several reasons for omitting these features:
 - Features that can be replaced trivially by external programs and wrapper
   scripts:
-  - Use ImageMagick's `convert` and shotgun's `-f pam` for JPEG output
+  - Use ImageMagick's `convert` and [shotgun's `-f pam`](#going-faster) for JPEG output
   - slop output is easy to process in a shell script
   - Use `sleep` instead of `-d`, since slop has to be called separately, this
     flag is not necessary
@@ -102,19 +102,19 @@ PNG encoder.
 
 ### Going faster
 The PNG encoder bottleneck can be avoided by using `-f pam`, this sets the output format to
-[Netpbm PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format), an uncompressed binary image format.
+[Netpbm PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format) - an uncompressed binary image format.
 
 By using an uncompressed format both encoding and decoding performance is improved:
+#### Encoding
 ```
->>># Encoding
->>>for i in {1..5}; do time ./target/release/shotgun -f png - > /dev/null; done
+>>> for i in {1..5}; do time ./target/release/shotgun -f png - > /dev/null; done
 ./target/release/shotgun -f png - > /dev/null  0.32s user 0.11s system 99% cpu 0.434 total
 ./target/release/shotgun -f png - > /dev/null  0.31s user 0.05s system 99% cpu 0.369 total
 ./target/release/shotgun -f png - > /dev/null  0.32s user 0.06s system 99% cpu 0.382 total
 ./target/release/shotgun -f png - > /dev/null  0.31s user 0.06s system 99% cpu 0.369 total
 ./target/release/shotgun -f png - > /dev/null  0.26s user 0.08s system 99% cpu 0.343 total
 
->>>for i in {1..5}; do time ./target/release/shotgun -f pam - > /dev/null; done
+>>> for i in {1..5}; do time ./target/release/shotgun -f pam - > /dev/null; done
 ./target/release/shotgun -f pam - > /dev/null  0.09s user 0.12s system 98% cpu 0.210 total
 ./target/release/shotgun -f pam - > /dev/null  0.07s user 0.07s system 99% cpu 0.141 total
 ./target/release/shotgun -f pam - > /dev/null  0.10s user 0.05s system 99% cpu 0.148 total
@@ -122,16 +122,16 @@ By using an uncompressed format both encoding and decoding performance is improv
 ./target/release/shotgun -f pam - > /dev/null  0.08s user 0.07s system 99% cpu 0.148 total
 ```
 
+#### Decoding (using ImageMagick to convert to jpg)
 ```
->>># Decoding (using ImageMagick to convert to jpg)
->>>for i in {1..5}; do time ./target/release/shotgun -f png - | convert - jpg:- > /dev/null; done
+>>> for i in {1..5}; do time ./target/release/shotgun -f png - | convert - jpg:- > /dev/null; done
 convert - jpg:- > /dev/null  0.59s user 0.16s system 89% cpu 0.842 total
 convert - jpg:- > /dev/null  0.58s user 0.16s system 95% cpu 0.763 total
 convert - jpg:- > /dev/null  0.55s user 0.20s system 97% cpu 0.764 total
 convert - jpg:- > /dev/null  0.53s user 0.15s system 89% cpu 0.758 total
 convert - jpg:- > /dev/null  0.61s user 0.16s system 100% cpu 0.762 total
 
->>>for i in {1..5}; do time ./target/release/shotgun -f pam - | convert - jpg:- > /dev/null; done
+>>> for i in {1..5}; do time ./target/release/shotgun -f pam - | convert - jpg:- > /dev/null; done
 convert - jpg:- > /dev/null  0.24s user 0.11s system 63% cpu 0.557 total
 convert - jpg:- > /dev/null  0.23s user 0.09s system 70% cpu 0.449 total
 convert - jpg:- > /dev/null  0.22s user 0.10s system 66% cpu 0.490 total

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ shotgun $sel $*
 There are several reasons for omitting these features:
 - Features that can be replaced trivially by external programs and wrapper
   scripts:
-  - Use ImageMagick's `convert` and shotgun's `-f pam` arg for JPEG output
+  - Use ImageMagick's `convert` and shotgun's `-f pam` for JPEG output
   - slop output is easy to process in a shell script
   - Use `sleep` instead of `-d`, since slop has to be called separately, this
     flag is not necessary

--- a/README.md
+++ b/README.md
@@ -100,6 +100,45 @@ streetwalrus@Akatsuki:~/source/shotgun(master)
 Further profiling has shown that the bottleneck in shotgun lies fully within the
 PNG encoder.
 
+### Going faster
+The PNG encoder bottleneck can be avoided by using `-f pam`, this sets the output format to
+[Netpbm PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format), an uncompressed binary image format.
+
+By using an uncompressed format both encoding and decoding performance is improved:
+```
+>>># Encoding
+>>>for i in {1..5}; do time ./target/release/shotgun -f png - > /dev/null; done
+./target/release/shotgun -f png - > /dev/null  0.32s user 0.11s system 99% cpu 0.434 total
+./target/release/shotgun -f png - > /dev/null  0.31s user 0.05s system 99% cpu 0.369 total
+./target/release/shotgun -f png - > /dev/null  0.32s user 0.06s system 99% cpu 0.382 total
+./target/release/shotgun -f png - > /dev/null  0.31s user 0.06s system 99% cpu 0.369 total
+./target/release/shotgun -f png - > /dev/null  0.26s user 0.08s system 99% cpu 0.343 total
+
+>>>for i in {1..5}; do time ./target/release/shotgun -f pam - > /dev/null; done
+./target/release/shotgun -f pam - > /dev/null  0.09s user 0.12s system 98% cpu 0.210 total
+./target/release/shotgun -f pam - > /dev/null  0.07s user 0.07s system 99% cpu 0.141 total
+./target/release/shotgun -f pam - > /dev/null  0.10s user 0.05s system 99% cpu 0.148 total
+./target/release/shotgun -f pam - > /dev/null  0.08s user 0.08s system 99% cpu 0.152 total
+./target/release/shotgun -f pam - > /dev/null  0.08s user 0.07s system 99% cpu 0.148 total
+```
+
+```
+>>># Decoding (using ImageMagick to convert to jpg)
+>>>for i in {1..5}; do time ./target/release/shotgun -f png - | convert - jpg:- > /dev/null; done
+convert - jpg:- > /dev/null  0.59s user 0.16s system 89% cpu 0.842 total
+convert - jpg:- > /dev/null  0.58s user 0.16s system 95% cpu 0.763 total
+convert - jpg:- > /dev/null  0.55s user 0.20s system 97% cpu 0.764 total
+convert - jpg:- > /dev/null  0.53s user 0.15s system 89% cpu 0.758 total
+convert - jpg:- > /dev/null  0.61s user 0.16s system 100% cpu 0.762 total
+
+>>>for i in {1..5}; do time ./target/release/shotgun -f pam - | convert - jpg:- > /dev/null; done
+convert - jpg:- > /dev/null  0.24s user 0.11s system 63% cpu 0.557 total
+convert - jpg:- > /dev/null  0.23s user 0.09s system 70% cpu 0.449 total
+convert - jpg:- > /dev/null  0.22s user 0.10s system 66% cpu 0.490 total
+convert - jpg:- > /dev/null  0.21s user 0.11s system 72% cpu 0.434 total
+convert - jpg:- > /dev/null  0.22s user 0.10s system 69% cpu 0.459 total
+```
+
 ## Installation
 
 - Manual: Make sure you have a recent Rust toolchain. Clone this repo, then run

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ shotgun $sel $*
 
 ## shotgun vs maim
 
-- Only PNG is supported
+- Only PNG and PAM are supported
 - Does not attempt to wrap slop
 - No cursor blending
 - Defaults to a time-stamped file instead of dumping raw PNG data into your
@@ -48,7 +48,7 @@ shotgun $sel $*
 There are several reasons for omitting these features:
 - Features that can be replaced trivially by external programs and wrapper
   scripts:
-  - Use ImageMagick's `convert` for JPEG output
+  - Use ImageMagick's `convert` and shotgun's `-f pam` arg for JPEG output
   - slop output is easy to process in a shell script
   - Use `sleep` instead of `-d`, since slop has to be called separately, this
     flag is not necessary

--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ Further profiling has shown that the bottleneck in shotgun lies fully within the
 PNG encoder.
 
 ### Going faster
-The PNG encoder bottleneck can be avoided by using `-f pam`, this sets the output format to
+The PNG encoder bottleneck can be avoided by using `-f pam`. This sets the output format to
 [Netpbm PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format) - an uncompressed binary image format.
 
 By using an uncompressed format both encoding and decoding performance is improved:
+
 #### Encoding
 ```
 >>> for i in {1..5}; do time ./target/release/shotgun -f png - > /dev/null; done

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use image::GenericImage;
 use image::Pixel;
 use image::RgbaImage;
 use image::Rgba;
-use image::pnm::*;
 extern crate libc;
 extern crate time;
 extern crate x11;
@@ -103,7 +102,7 @@ fn run() -> i32 {
 
     let output_format = match output_ext {
         "png" => image::ImageOutputFormat::PNG,
-        "pam" => image::ImageOutputFormat::PNM(PNMSubtype::ArbitraryMap),
+        "pam" => image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::ArbitraryMap),
         _ => image::ImageOutputFormat::PNG,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,23 +87,14 @@ fn run() -> i32 {
         None => root,
     };
 
-    let output_ext = match matches.opt_str("f") {
-        Some(s) => match s.to_lowercase().as_ref() {
-            "png" => "png",
-            "pam" => "pam",
-            _ => {
-                eprintln!("Invalid output format specified");
-                usage(&progname, opts);
-                return 1;
-            }
-        },
-        None => "png",
-    };
-
-    let output_format = match output_ext {
+    let output_ext = matches.opt_str("f").unwrap_or("png".to_string()).to_lowercase();
+    let output_format = match output_ext.as_ref() {
         "png" => image::ImageOutputFormat::PNG,
         "pam" => image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::ArbitraryMap),
-        _ => image::ImageOutputFormat::PNG,
+        _ => {
+            eprintln!("Invalid image format specified");
+            return 1;
+        }
     };
 
     let window_rect = display.get_window_rect(window);

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,9 +93,10 @@ fn run() -> i32 {
             "png" => "png",
             "pam" => "pam",
             _ => {
-                eprintln!("Invalid image format specified, defaulting to png");
-                "png"
-            },
+                eprintln!("Invalid output format specified");
+                usage(&progname, opts);
+                return 1;
+            }
         },
         None => "png",
     };


### PR DESCRIPTION
[PAM](https://en.wikipedia.org/wiki/Netpbm#PAM_graphics_format) is an uncompressed binary image format.

The main advantage of an uncompressed image format is faster encoding and decoding:
![image](https://user-images.githubusercontent.com/13610073/53086707-8688e700-34fd-11e9-975c-765a386114ee.png)
(in each run the first time is shotgun and second is imagemagick)

Ideally this would be BMP or PPM but:  
- BMP encoding is very slow in the image crate (I haven't figured out exactly why, but cargo-profiler points me to slow IO [maybe it's not buffered or something])
- The image crate does not write an alpha channel for BMP images
- PPM does not support an alpha channel
