### PR TITLE
Cast to `*const raw::c_char` instead of `*const i8` in `src/xwrap.rs`

### DIFF
--- a/src/xwrap.rs
+++ b/src/xwrap.rs
@@ -248,7 +248,7 @@ pub fn parse_geometry(g: ffi::CString) -> util::Rect {
         let mut y = 0;
         let mut w = 0;
         let mut h = 0;
-        xlib::XParseGeometry(g.as_ptr() as *const i8, &mut x, &mut y, &mut w, &mut h);
+        xlib::XParseGeometry(g.as_ptr() as *const raw::c_char, &mut x, &mut y, &mut w, &mut h);
 
         util::Rect {
             x: x,


### PR DESCRIPTION
This will hopefully fix the aarch64-linux build in https://github.com/NixOS/nixpkgs/pull/72100.