### PR TITLE
Add delay (-d) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options:
                         Area to capture
     -f, --format png/pam
                         Output format
+    -d, --delay seconds Delay capture
     -h, --help          Print help and exit
     -v, --version       Print version and exit
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::process;
+use std::thread;
 
 extern crate getopts;
 use getopts::Options;
@@ -38,6 +39,7 @@ fn run() -> i32 {
     opts.optopt("i", "id", "Window to capture", "ID");
     opts.optopt("g", "geometry", "Area to capture", "WxH+X+Y");
     opts.optopt("f", "format", "Output format", "png/pam");
+    opts.optopt("d", "delay", "Delay capture", "seconds");
     opts.optflag("h", "help", "Print help and exit");
     opts.optflag("v", "version", "Print version and exit");
 
@@ -120,6 +122,16 @@ fn run() -> i32 {
             w: window_rect.w,
             h: window_rect.h,
         },
+    };
+
+    if let Some(delay) = matches.opt_str("d") {
+        match delay.parse::<u64>() {
+            Ok(secs) => thread::sleep(std::time::Duration::from_secs(secs)),
+            Err(_) => {
+                eprintln!("Invalid delay \"{}\" specified", delay);
+                return 1;
+            },
+        }
     };
 
     let image = match display.get_image(window, sel, xwrap::ALL_PLANES, xlib::ZPixmap) {


### PR DESCRIPTION
**Rationale**: sometimes you want a delay between the moment you make a selection and the shot itself. Typical use-case: you want to take a screenshot of an opened combo box on a random UI.

While it is technically possible with something like `shotgun $(slop -f "-i %i -g %g" && sleep 5)`, it requires the user' script/function/alias to actually parse an optional delay option and inject the sleep, which can be very cumbersome if you already forward all arguments to `shotgun`.

In practice, this patch allows to define `alias shot='shotgun $(slop -f "-i %i -g %g")'` in order to call `shot`, `shot -d 5`, etc.

The patch shouldn't be too intrusive, but since it's my first rust contribution ever, it's likely that I haven't followed the ideal idioms.