### PR TITLE
Add filename printing flag (-p)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options:
                         Area to capture
     -f, --format png/pam
                         Output format
+    -p, --print-path    Print filename on stdout
     -h, --help          Print help and exit
     -v, --version       Print version and exit
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ fn run() -> i32 {
     opts.optopt("i", "id", "Window to capture", "ID");
     opts.optopt("g", "geometry", "Area to capture", "WxH+X+Y");
     opts.optopt("f", "format", "Output format", "png/pam");
+    opts.optflag("p", "print-path", "Print filename on stdout");
     opts.optflag("h", "help", "Print help and exit");
     opts.optflag("v", "version", "Print version and exit");
 
@@ -192,6 +193,14 @@ fn run() -> i32 {
                 eprintln!("Failed to create {}: {}", path, e);
                 return 1
             },
+        }
+    }
+
+    if matches.opt_present("p") {
+        if path == "-" {
+            eprintln!("stdout is used to print the image, -p option ignored");
+        } else {
+            println!("{}", path);
         }
     }
 


### PR DESCRIPTION
This is useful when scripting around `shotgun`.

**Example**: let's say you have a script calling `shotgun` and you want to do something with the resulting file (such as uploading it somewhere). If the script forwards the user arguments, you get in the situation where the user can either specify a custom filename, or use the default shotgun naming. In the latter situation, the only way for the script to figure out the filename is to parse the unreliable `stderr` output. Using `-p` makes it possible to get the filename in both cases easily.

**Note**: this PR will conflict with the previous one I made earlier (due to option being close). Ping me on this one or the other whenever you need me to rebase.