### PR TITLE
Restore streaming output writes

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -49,3 +49,21 @@ pub fn parse_int<T: num_traits::Num>(string: &str) -> Result<T, T::FromStrRadixE
         _ => T::from_str_radix(string, 10),
     }
 }
+
+use image::EncodableLayout;
+pub fn write_image_buffer_with_encoder<P, Container>(
+    image: &image::ImageBuffer<P, Container>,
+    encoder: impl image::ImageEncoder,
+) -> image::ImageResult<()>
+where
+    P: image::PixelWithColorType,
+    [P::Subpixel]: image::EncodableLayout,
+    Container: core::ops::Deref<Target = [P::Subpixel]>,
+{
+    encoder.write_image(
+        image.as_raw().as_bytes(),
+        image.width(),
+        image.height(),
+        P::COLOR_TYPE,
+    )
+}


### PR DESCRIPTION
During the upgrade from image 0.23 to 0.24, `ImageBuffer::write_to()` was changed to require a seekable writer.
This doesn't work when writing to stdout, so we were forced to buffer the output before writing it out in one go.

It turns out that most individual encoders don't actually require seeking, and neither of the two we use does.
Restore streaming behavior by invoking encoders directly.

See: https://github.com/image-rs/image/issues/1922

This still requires testing.