### PR TITLE
Port to x11rb

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup environment
       run: |
-        sudo apt-get install libx11-dev libx11-xcb-dev libxrandr-dev
+        sudo apt-get install libx11-dev libx11-xcb-dev
         echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
     - name: rustfmt
       run: cargo fmt -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup environment
       run: |
-        sudo apt-get install libx11-dev
         echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
     - name: rustfmt
       run: cargo fmt -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup environment
       run: |
-        sudo apt-get install libx11-dev libx11-xcb-dev
+        sudo apt-get install libx11-dev
         echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
     - name: rustfmt
       run: cargo fmt -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup environment
       run: |
-        sudo apt-get install libx11-dev libxrandr-dev
+        sudo apt-get install libx11-dev libx11-xcb-dev libxrandr-dev
         echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
     - name: rustfmt
       run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,12 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
 name = "png"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,7 +216,6 @@ dependencies = [
  "image",
  "nom",
  "num-traits",
- "x11",
  "x11rb",
 ]
 
@@ -268,16 +261,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x11"
-version = "2.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
-dependencies = [
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "x11rb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +128,19 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -168,6 +200,7 @@ dependencies = [
  "image",
  "num-traits",
  "x11",
+ "x11rb",
 ]
 
 [[package]]
@@ -183,6 +216,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,4 +254,27 @@ checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
+dependencies = [
+ "gethostname",
+ "libc",
+ "nix",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
+dependencies = [
+ "nix",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -141,6 +153,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -198,6 +220,7 @@ version = "2.4.0"
 dependencies = [
  "getopts",
  "image",
+ "nom",
  "num-traits",
  "x11",
  "x11rb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
 dependencies = [
  "gethostname",
- "libc",
  "nix",
  "winapi",
  "winapi-wsapoll",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ features = ["png", "pnm"]
 
 [dependencies.x11]
 version = "2.21.0"
-features = ["xlib", "xlib_xcb", "xrandr"]
+features = ["xlib", "xlib_xcb"]
 
 [dependencies.x11rb]
 version = "0.11.1"
-features = ["allow-unsafe-code"]
+features = ["allow-unsafe-code", "randr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 getopts = "0.2"
 num-traits = "0.2"
+nom = "7.1.3"
 
 [dependencies.image]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ features = ["png", "pnm"]
 
 [dependencies.x11]
 version = "2.21.0"
-features = ["xlib", "xlib_xcb"]
+features = ["xlib"]
 
 [dependencies.x11rb]
 version = "0.11.1"
-features = ["allow-unsafe-code", "randr"]
+features = ["randr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,8 @@ features = ["png", "pnm"]
 
 [dependencies.x11]
 version = "2.21.0"
-features = ["xlib", "xrandr"]
+features = ["xlib", "xlib_xcb", "xrandr"]
+
+[dependencies.x11rb]
+version = "0.11.1"
+features = ["allow-unsafe-code"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ default-features = false
 version = "0.24.6"
 features = ["png", "pnm"]
 
-[dependencies.x11]
-version = "2.21.0"
-features = ["xlib"]
-
 [dependencies.x11rb]
 version = "0.11.1"
 features = ["randr"]

--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ Summary
 ## Installation
 
 - From source:
-  - install a recent Rust toolchain and libx11 (depending on your distribution,
-    you may need to install development headers separately)
+  - install a recent Rust toolchain
   - clone this repository and run `cargo install --path .`
   - or install from [crates.io](https://crates.io/crates/shotgun):
     `cargo install shotgun`

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Summary
 ## Installation
 
 - From source:
-  - install a recent Rust toolchain, libx11 and libxrandr (depending on your
-    distribution, you may need to install development headers separately)
+  - install a recent Rust toolchain and libx11 (depending on your distribution,
+    you may need to install development headers separately)
   - clone this repository and run `cargo install --path .`
   - or install from [crates.io](https://crates.io/crates/shotgun):
     `cargo install shotgun`

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,6 @@ in pkgs.mkShell {
     p.clippy
 
     p.xorg.libX11
-    p.xorg.libXrandr
     p.pkgconfig
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -11,8 +11,5 @@ in pkgs.mkShell {
     p.rustc
     p.rustfmt
     p.clippy
-
-    p.xorg.libX11
-    p.pkgconfig
   ];
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn run() -> i32 {
             return 1;
         }
     };
-    let root = display.get_default_root();
+    let root = display.root();
 
     let window = match matches.opt_str("i") {
         Some(s) => match util::parse_int::<xlib::Window>(&s) {
@@ -143,7 +143,7 @@ fn run() -> i32 {
         },
     };
 
-    let screen_rects: Vec<util::Rect> = match display.get_screen_rects(root) {
+    let screen_rects: Vec<util::Rect> = match display.get_screen_rects() {
         Some(r) => r.collect(),
         None => {
             eprintln!("Failed to get screen rects");
@@ -152,7 +152,7 @@ fn run() -> i32 {
     };
 
     if matches.opt_present("s") {
-        let cursor = match display.get_cursor_position(root) {
+        let cursor = match display.get_cursor_position() {
             Some(c) => c,
             None => {
                 eprintln!("Failed to get cursor position");

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,8 @@ fn run() -> i32 {
         },
     };
 
-    let screen_rects: Vec<util::Rect> = match display.get_screen_rects() {
-        Some(r) => r.collect(),
+    let screen_rects = match display.get_screen_rects() {
+        Some(r) => r,
         None => {
             eprintln!("Failed to get screen rects");
             return 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::env;
-use std::ffi::CString;
 use std::fs::File;
 use std::io;
 use std::path::Path;
@@ -126,9 +125,7 @@ fn run() -> i32 {
     }
 
     let mut sel = match matches.opt_str("g") {
-        Some(s) => match xwrap::parse_geometry(CString::new(s).expect("Failed to convert CString"))
-            .intersection(window_rect)
-        {
+        Some(s) => match util::parse_geometry(&s).and_then(|g| g.intersection(window_rect)) {
             Some(sel) => util::Rect {
                 // Selection is relative to the root window (whole screen)
                 x: sel.x - window_rect.x,

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,13 @@ fn run() -> i32 {
         }
     };
 
-    let window_rect = display.get_window_rect(window);
+    let window_rect = match display.get_window_geometry(window) {
+        Some(r) => r,
+        None => {
+            eprintln!("Failed to get window geometry");
+            return 1;
+        }
+    };
 
     if matches.opt_present("s") {
         if matches.opt_present("g") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use image::GenericImageView;
 use image::ImageOutputFormat;
 use image::Rgba;
 use image::RgbaImage;
-use x11::xlib;
+use x11rb::protocol::xproto;
 
 mod util;
 mod xwrap;
@@ -82,7 +82,7 @@ fn run() -> i32 {
     let root = display.root();
 
     let window = match matches.opt_str("i") {
-        Some(s) => match util::parse_int::<xlib::Window>(&s) {
+        Some(s) => match util::parse_int::<xproto::Window>(&s) {
             Ok(r) => r,
             Err(_) => {
                 eprintln!("Window ID is not a valid integer");

--- a/src/xwrap.rs
+++ b/src/xwrap.rs
@@ -5,7 +5,6 @@
 use std::ffi;
 use std::os::raw;
 use std::ptr;
-use std::slice;
 
 use image::Rgba;
 use image::RgbaImage;
@@ -25,7 +24,12 @@ pub struct Display {
 }
 
 pub struct Image {
-    handle: *mut xlib::XImage,
+    w: u32,
+    h: u32,
+    format: xproto::Format,
+    visual: xproto::Visualtype,
+    byte_order: xproto::ImageOrder,
+    data: Vec<u8>,
 }
 
 impl Display {
@@ -92,22 +96,52 @@ impl Display {
         }
     }
 
-    pub fn get_image(&self, window: xproto::Window, rect: util::Rect) -> Option<Image> {
-        unsafe {
-            let all_planes = !0;
-            let image = xlib::XGetImage(
-                self.handle,
-                window as _,
-                rect.x,
-                rect.y,
-                rect.w as std::ffi::c_uint,
-                rect.h as std::ffi::c_uint,
-                all_planes,
-                xlib::ZPixmap,
-            );
-
-            Image::from_raw_ximage(image)
+    fn find_visual(&self, id: xproto::Visualid) -> Option<&xproto::Visualtype> {
+        for screen in &self.conn.setup().roots {
+            for depth in &screen.allowed_depths {
+                for visual in &depth.visuals {
+                    if visual.visual_id == id {
+                        return Some(visual);
+                    }
+                }
+            }
         }
+        None
+    }
+
+    pub fn get_image(&self, window: xproto::Window, rect: util::Rect) -> Option<Image> {
+        const ALL_PLANES: u32 = !0;
+        let cookie = self
+            .conn
+            .get_image(
+                xproto::ImageFormat::Z_PIXMAP,
+                window,
+                rect.x as i16,
+                rect.y as i16,
+                rect.w as u16,
+                rect.h as u16,
+                ALL_PLANES,
+            )
+            .ok()?;
+        let img = cookie.reply().ok()?;
+
+        let format = *self
+            .conn
+            .setup()
+            .pixmap_formats
+            .iter()
+            .find(|f| f.depth == img.depth)?;
+        let visual = *self.find_visual(img.visual)?;
+        let byte_order = self.conn.setup().image_byte_order;
+
+        Some(Image {
+            w: rect.w as u32,
+            h: rect.h as u32,
+            format,
+            visual,
+            byte_order,
+            data: img.data,
+        })
     }
 
     pub fn get_screen_rects(&self) -> Option<Vec<util::Rect>> {
@@ -157,65 +191,64 @@ impl Drop for Display {
 }
 
 impl Image {
-    fn from_raw_ximage(ximage: *mut xlib::XImage) -> Option<Image> {
-        if ximage.is_null() {
-            None
-        } else {
-            Some(Image { handle: ximage })
-        }
-    }
-
     pub fn to_image_buffer(&self) -> Option<RgbaImage> {
-        let img = unsafe { &*self.handle };
-
-        if (img.red_mask, img.green_mask, img.blue_mask) == (0xF800, 0x07E0, 0x001F) {
+        if (
+            self.visual.red_mask,
+            self.visual.green_mask,
+            self.visual.blue_mask,
+        ) == (0xF800, 0x07E0, 0x001F)
+        {
             return self.to_image_buffer_rgb565();
         }
 
-        let bytes_per_pixel = match (img.depth, img.bits_per_pixel) {
-            (24, 24) => 3,
-            (24, 32) | (32, 32) => 4,
+        let bytes_per_pixel = match (self.format.depth, self.format.bits_per_pixel) {
+            (24, bpp @ 24) | (24 | 32, bpp @ 32) => bpp as u32 / 8,
             _ => return None,
         };
+
+        let pad = match self.format.scanline_pad {
+            p @ 32 => p as u32 / 8,
+            _ => return None,
+        };
+        let bytes_per_line = (self.w * bytes_per_pixel + pad - 1) / pad * pad;
 
         // Compute subpixel offsets into each pixel according the the bitmasks X gives us
         // Only 8 bit, byte-aligned values are supported
         // Truncate masks to the lower 32 bits as that is the maximum pixel size
         macro_rules! channel_offset {
-            ($mask:expr) => {
-                match (img.byte_order, $mask & 0xFFFFFFFF) {
-                    (0, 0xFF) | (1, 0xFF000000) => 0,
-                    (0, 0xFF00) | (1, 0xFF0000) => 1,
-                    (0, 0xFF0000) | (1, 0xFF00) => 2,
-                    (0, 0xFF000000) | (1, 0xFF) => 3,
+            ($mask:expr) => {{
+                use xproto::ImageOrder as O;
+                match (self.byte_order, $mask & 0xFFFFFFFF) {
+                    (O::LSB_FIRST, 0xFF) | (O::MSB_FIRST, 0xFF000000) => 0,
+                    (O::LSB_FIRST, 0xFF00) | (O::MSB_FIRST, 0xFF0000) => 1,
+                    (O::LSB_FIRST, 0xFF0000) | (O::MSB_FIRST, 0xFF00) => 2,
+                    (O::LSB_FIRST, 0xFF000000) | (O::MSB_FIRST, 0xFF) => 3,
                     _ => return None,
                 }
-            };
+            }};
         }
-        let red_offset = channel_offset!(img.red_mask);
-        let green_offset = channel_offset!(img.green_mask);
-        let blue_offset = channel_offset!(img.blue_mask);
-        let alpha_offset = channel_offset!(!(img.red_mask | img.green_mask | img.blue_mask));
-
-        // Wrap the pixel buffer into a slice
-        let size = (img.bytes_per_line * img.height) as usize;
-        let data = unsafe { slice::from_raw_parts(img.data as *const u8, size) };
+        let red_offset = channel_offset!(self.visual.red_mask);
+        let green_offset = channel_offset!(self.visual.green_mask);
+        let blue_offset = channel_offset!(self.visual.blue_mask);
+        let alpha_offset = channel_offset!(
+            !(self.visual.red_mask | self.visual.green_mask | self.visual.blue_mask)
+        );
 
         // Finally, generate the image object
         Some(RgbaImage::from_fn(
-            img.width as u32,
-            img.height as u32,
+            self.w,
+            self.h,
             |x, y| {
-                let offset = (y * img.bytes_per_line as u32 + x * bytes_per_pixel) as usize;
+                let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
                 Rgba([
-                    data[offset + red_offset],
-                    data[offset + green_offset],
-                    data[offset + blue_offset],
+                    self.data[offset + red_offset],
+                    self.data[offset + green_offset],
+                    self.data[offset + blue_offset],
                     // Make the alpha channel fully opaque if none is provided
-                    if img.depth == 24 {
+                    if self.format.depth == 24 {
                         0xFF
                     } else {
-                        data[offset + alpha_offset]
+                        self.data[offset + alpha_offset]
                     },
                 ])
             },
@@ -223,25 +256,25 @@ impl Image {
     }
 
     fn to_image_buffer_rgb565(&self) -> Option<RgbaImage> {
-        let img = unsafe { &*self.handle };
-
-        if img.depth != 16 || img.bits_per_pixel != 16 {
+        if self.format.depth != 16 || self.format.bits_per_pixel != 16 {
             return None;
         }
         let bytes_per_pixel = 2;
 
-        // Wrap the pixel buffer into a slice
-        let size = (img.bytes_per_line * img.height) as usize;
-        let data = unsafe { slice::from_raw_parts(img.data as *const u8, size) };
+        let pad = match self.format.scanline_pad {
+            p @ (16 | 32) => p as u32 / 8,
+            _ => return None,
+        };
+        let bytes_per_line = (self.w * bytes_per_pixel + pad - 1) / pad * pad;
 
         // Finally, generate the image object
         Some(RgbaImage::from_fn(
-            img.width as u32,
-            img.height as u32,
+            self.w,
+            self.h,
             |x, y| {
-                let offset = (y * img.bytes_per_line as u32 + x * bytes_per_pixel) as usize;
-                let pixel_slice = [data[offset], data[offset + 1]];
-                let pixel = if img.byte_order == 0 {
+                let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
+                let pixel_slice = [self.data[offset], self.data[offset + 1]];
+                let pixel = if self.byte_order == xproto::ImageOrder::LSB_FIRST {
                     u16::from_le_bytes(pixel_slice)
                 } else {
                     u16::from_be_bytes(pixel_slice)
@@ -257,14 +290,6 @@ impl Image {
                 ])
             },
         ))
-    }
-}
-
-impl Drop for Image {
-    fn drop(&mut self) {
-        unsafe {
-            xlib::XDestroyImage(self.handle);
-        }
     }
 }
 

--- a/src/xwrap.rs
+++ b/src/xwrap.rs
@@ -47,7 +47,7 @@ impl Display {
         }
     }
 
-    pub fn get_default_root(&self) -> xlib::Window {
+    pub fn root(&self) -> xlib::Window {
         unsafe { xlib::XDefaultRootWindow(self.handle) }
     }
 
@@ -117,9 +117,9 @@ impl Display {
         }
     }
 
-    pub fn get_screen_rects(&self, root: xlib::Window) -> Option<ScreenRectIter<'_>> {
+    pub fn get_screen_rects(&self) -> Option<ScreenRectIter<'_>> {
         unsafe {
-            let xrr_res = xrandr::XRRGetScreenResourcesCurrent(self.handle, root);
+            let xrr_res = xrandr::XRRGetScreenResourcesCurrent(self.handle, self.root());
 
             if xrr_res.is_null() {
                 None
@@ -134,14 +134,14 @@ impl Display {
         }
     }
 
-    pub fn get_cursor_position(&self, window: xlib::Window) -> Option<util::Point> {
+    pub fn get_cursor_position(&self) -> Option<util::Point> {
         let mut x = 0;
         let mut y = 0;
 
         unsafe {
             if xlib::XQueryPointer(
                 self.handle,
-                window,
+                self.root(),
                 &mut 0,
                 &mut 0,
                 &mut x,

--- a/src/xwrap.rs
+++ b/src/xwrap.rs
@@ -2,12 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::ffi;
-use std::os::raw;
-
 use image::Rgba;
 use image::RgbaImage;
-use x11::xlib;
 use x11rb::connection::Connection;
 use x11rb::protocol::randr::ConnectionExt as _;
 use x11rb::protocol::xproto::{self, ConnectionExt as _};
@@ -250,28 +246,5 @@ impl Image {
                 0xFF,
             ])
         }))
-    }
-}
-
-pub fn parse_geometry(g: ffi::CString) -> util::Rect {
-    unsafe {
-        let mut x = 0;
-        let mut y = 0;
-        let mut w = 0;
-        let mut h = 0;
-        xlib::XParseGeometry(
-            g.as_ptr() as *const raw::c_char,
-            &mut x,
-            &mut y,
-            &mut w,
-            &mut h,
-        );
-
-        util::Rect {
-            x,
-            y,
-            w: w as i32,
-            h: h as i32,
-        }
     }
 }

--- a/src/xwrap.rs
+++ b/src/xwrap.rs
@@ -235,24 +235,20 @@ impl Image {
         );
 
         // Finally, generate the image object
-        Some(RgbaImage::from_fn(
-            self.w,
-            self.h,
-            |x, y| {
-                let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
-                Rgba([
-                    self.data[offset + red_offset],
-                    self.data[offset + green_offset],
-                    self.data[offset + blue_offset],
-                    // Make the alpha channel fully opaque if none is provided
-                    if self.format.depth == 24 {
-                        0xFF
-                    } else {
-                        self.data[offset + alpha_offset]
-                    },
-                ])
-            },
-        ))
+        Some(RgbaImage::from_fn(self.w, self.h, |x, y| {
+            let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
+            Rgba([
+                self.data[offset + red_offset],
+                self.data[offset + green_offset],
+                self.data[offset + blue_offset],
+                // Make the alpha channel fully opaque if none is provided
+                if self.format.depth == 24 {
+                    0xFF
+                } else {
+                    self.data[offset + alpha_offset]
+                },
+            ])
+        }))
     }
 
     fn to_image_buffer_rgb565(&self) -> Option<RgbaImage> {
@@ -268,28 +264,24 @@ impl Image {
         let bytes_per_line = (self.w * bytes_per_pixel + pad - 1) / pad * pad;
 
         // Finally, generate the image object
-        Some(RgbaImage::from_fn(
-            self.w,
-            self.h,
-            |x, y| {
-                let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
-                let pixel_slice = [self.data[offset], self.data[offset + 1]];
-                let pixel = if self.byte_order == xproto::ImageOrder::LSB_FIRST {
-                    u16::from_le_bytes(pixel_slice)
-                } else {
-                    u16::from_be_bytes(pixel_slice)
-                };
-                let red = (pixel >> 11) & 0x1F;
-                let green = (pixel >> 5) & 0x3F;
-                let blue = pixel & 0x1F;
-                Rgba([
-                    (red << 3 | red >> 2) as u8,
-                    (green << 2 | green >> 4) as u8,
-                    (blue << 3 | blue >> 2) as u8,
-                    0xFF,
-                ])
-            },
-        ))
+        Some(RgbaImage::from_fn(self.w, self.h, |x, y| {
+            let offset = (y * bytes_per_line + x * bytes_per_pixel) as usize;
+            let pixel_slice = [self.data[offset], self.data[offset + 1]];
+            let pixel = if self.byte_order == xproto::ImageOrder::LSB_FIRST {
+                u16::from_le_bytes(pixel_slice)
+            } else {
+                u16::from_be_bytes(pixel_slice)
+            };
+            let red = (pixel >> 11) & 0x1F;
+            let green = (pixel >> 5) & 0x3F;
+            let blue = pixel & 0x1F;
+            Rgba([
+                (red << 3 | red >> 2) as u8,
+                (green << 2 | green >> 4) as u8,
+                (blue << 3 | blue >> 2) as u8,
+                0xFF,
+            ])
+        }))
     }
 }
 


### PR DESCRIPTION
The long awaited.

This shouldn't be an overly difficult task, but it will need some care. One problem in particular is that xlib provides some utility functions that have no equivalent in XCB and x11rb, so they may need to be re-implemented in rust. Luckily, we can work on the port progressively thanks to the possibility to share the underlying XCB connection between x11rb and xlib.

One of the primary motivations for this port, besides switching to a vastly superior library, is the ability to build a completely self-contained static binary. Once the port is complete and no xlib code is left, we can switch over to the pure rust RustConnection instead of XCBConnection.

I've done some initial porting work. Because it's WIP, this PR is a draft. PRs against this branch are welcome. When the port is complete, we can do a final review here and then finally merge into master.