### PR TITLE
Adding a Manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Features:
 - *On average, shotgun is more than twice as fast as maim*
 
 ## Usage
+See the man page: `docs/shotgun.1`.
 
 ```
 Usage: shotgun [options] [file]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
+use std::path::Path;
 use std::process::Command;
+use std::{str, env, fs};
 
 fn main() {
+    add_manpage("shotgun.1");
+        
     let git_version = Command::new("git").arg("describe").arg("--tags").output();
     if let Ok(git_version) = git_version {
         if git_version.status.success() {
@@ -10,3 +14,28 @@ fn main() {
         }
     }
 }
+
+fn add_manpage(manpage: &str) {
+    let manpage_source_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("docs/").join(manpage);
+
+    let root_path: String = match env::var("CARGO_INSTALL_ROOT") {
+        Ok(r) => r,
+        Err(_) => env::var("HOME").unwrap() + "/.cargo/",
+    };
+    let destination_path = root_path + "man/man1/";
+
+    let manpath = Command::new("manpath").output().expect("Couldn't run \"manpath\"").stdout;
+    let manpath_parsed = str::from_utf8(&manpath).unwrap(); // could next check $MANPATH, but if the manpath command
+                                                            // doesn't exsist that probably wont either. It's likely
+                                                            // they don't have man installed.
+    if !manpath_parsed.contains(&destination_path) {
+        println!("cargo:warning=Looks like \"{}\" isn't on your manpath, to see the man page please add it. See `man manpath`", destination_path);
+    }
+
+    let mut dir_builder = fs::DirBuilder::new();
+    dir_builder.recursive(true);
+    dir_builder.create(&destination_path).expect("Failed to create manpage's parent directories.");
+    fs::copy(manpage_source_path, destination_path.clone() + manpage).expect(&format!("Failed to install manpage to {}", destination_path));
+
+}
+

--- a/docs/shotgun.1
+++ b/docs/shotgun.1
@@ -1,5 +1,5 @@
-.TH shotgun 1 "08/31/2023" "2.5.1" "User Commands"
-.SH NAME
+.TH SHOTGUN 1 "08/31/2023" "2.5.1" "User Commands"
+.SH SHOTGUN 
 shotgun \- Minimal X screenshot utility 
 .SH SYNOPSIS
 shotgun [\fIOPTIONS\fP] [\fIFILE\fP]
@@ -35,4 +35,5 @@ Print version and exit
 \fIfile\fP can be either a file name of which you would like to save the image to, or when using the "-" charicter as the file name it will pipe the image to STDOUT.
 .SH AUTHOR
 neXromancers
-
+.SH BUGS
+Please report bugs here: https://github.com/neXromancers/shotgun/issues

--- a/shotgun.man
+++ b/shotgun.man
@@ -1,0 +1,38 @@
+.TH shotgun 1 "08/31/2023" "2.5.1" "User Commands"
+.SH NAME
+shotgun \- Minimal X screenshot utility 
+.SH SYNOPSIS
+shotgun [\fIOPTIONS\fP] [\fIFILE\fP]
+.SH DESCRIPTION
+A minimal screenshot utility for X11.
+.SS SUPPORTS
+.TP
+Exporting to PNG/STDOUT
+.TP
+Masksing off-screen areas on multi-head setups
+.TP
+Selecting by window ID and geometry
+.SS OPTIONS
+.TP
+\fB-i, --id\fP ID
+Window to capture
+.TP
+\fB-g, --geometry\fP WxH+X+Y
+Area to capture
+.TP
+\fB-f, --format\fP
+Either png/pam as output format
+.TP
+\fB-s, --screen\fP
+Capture the current screen
+.TP
+\fB-h, --help\fP
+Print help and exit
+.TP
+\fB-v, --version\fP
+Print version and exit
+.SH FILE
+\fIfile\fP can be either a file name of which you would like to save the image to, or when using the "-" charicter as the file name it will pipe the image to STDOUT.
+.SH AUTHOR
+neXromancers
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod xwrap;
 use crate::xwrap::Display;
 
 fn usage(progname: &str, opts: getopts::Options) {
-    let brief = format!("Usage: {progname} [options] [file]");
+    let brief = format!("Usage: {progname} [options] [file]\nNote: use - as [file] for stdout");
     let usage = opts.usage(&brief);
     eprint!("{usage}");
 }


### PR DESCRIPTION
In #44 a manpage was added, this PR now installed the manpage to relative to the location that the program was installed in.
Ex:
program: `~/.cargo/bin/shotgun`
manpage: `~/.cargo/man/man1/shotugn.1`

This path isn't, by default, on the manpath thus it would require more configuration from the user's end. It could also be installed onto one of the existing manpath(s) but this would break convention. LMK your thoughts.